### PR TITLE
chore: remove copyright notice in the header of each file and navigate to license files instead

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -43,10 +43,12 @@ mlc --ignore-path target
 ''']
 
 [tasks.copyright]
-script = ['''
+script = [
+  '''
 #!/usr/bin/env bash -eux
-for rs in $(git ls-files |grep -e '\.rs$') ; do grep '// Copyright (c) 2021-2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.' $rs ; done
-''']
+for rs in $(git ls-files |grep -e '\.rs$') ; do grep '// This file is part of https://github.com/SpringQL/replayman which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.' $rs ; done
+''',
+]
 
 [tasks.publish]
 script = [

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/replayman which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod mqtt_agent;
 mod tcp_agent;

--- a/src/agent/mqtt_agent.rs
+++ b/src/agent/mqtt_agent.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/replayman which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::Result;
 use rumqttc::{Client, Connection, MqttOptions, QoS};

--- a/src/agent/tcp_agent.rs
+++ b/src/agent/tcp_agent.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/replayman which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::{Context, Result};
 use std::{

--- a/src/cmd_parser.rs
+++ b/src/cmd_parser.rs
@@ -10,7 +10,7 @@ use springql_foreign_service::source::source_input::{
 
 use crate::destination::Destination;
 
-// Copyright (c) 2021-2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/replayman which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 /// Log agent to replay time-stamped log stream.
 #[derive(Parser)]

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/replayman which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::net::SocketAddr;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/replayman which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod agent;
 mod cmd_parser;


### PR DESCRIPTION
refs: https://github.com/SpringQL/SpringQL/pull/76